### PR TITLE
Copy Frameworks Script for Reactive Swift

### DIFF
--- a/ReactiveJSON.xcodeproj/project.pbxproj
+++ b/ReactiveJSON.xcodeproj/project.pbxproj
@@ -193,6 +193,7 @@
 			buildPhases = (
 				0ADB4BAD1D637F3C008CF654 /* Sources */,
 				0ADB4BAE1D637F3C008CF654 /* Frameworks */,
+				4942D6D21E0DC47000BE3EE1 /* Copy Frameworks Script */,
 				0ADB4BAF1D637F3C008CF654 /* Headers */,
 				0ADB4BB01D637F3C008CF654 /* Resources */,
 			);
@@ -291,6 +292,21 @@
 				Nimble,
 				Quick,
 			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "case \"$PLATFORM_NAME\" in\nmacosx) plat=Mac;;\niphone*) plat=iOS;;\nwatch*) plat=watchOS;;\ntv*) plat=tvOS;;\n*) echo \"error: Unknown PLATFORM_NAME: $PLATFORM_NAME\"; exit 1;;\nesac\nfor (( n = 0; n < SCRIPT_INPUT_FILE_COUNT; n++ )); do\nVAR=SCRIPT_INPUT_FILE_$n\nframework=$(basename \"${!VAR}\")\nexport SCRIPT_INPUT_FILE_$n=\"$SRCROOT\"/Carthage/Build/$plat/\"$framework\".framework\ndone\n\n/usr/local/bin/carthage copy-frameworks || exit\n\nfor (( n = 0; n < SCRIPT_INPUT_FILE_COUNT; n++ )); do\nVAR=SCRIPT_INPUT_FILE_$n\nsource=${!VAR}.dSYM\ndest=${BUILT_PRODUCTS_DIR}/$(basename \"$source\")\nditto \"$source\" \"$dest\" || exit\ndone";
+		};
+		4942D6D21E0DC47000BE3EE1 /* Copy Frameworks Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 12;
+			files = (
+			);
+			inputPaths = (
+				ReactiveSwift,
+			);
+			name = "Copy Frameworks Script";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
I'm pretty sure we need the copy frameworks script in order to build ReactiveJSON as a standalone framework and run unit tests.